### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/joyride/models.py
+++ b/joyride/models.py
@@ -251,7 +251,7 @@ class JoyRide(models.Model):
         
         j.update({'cookieDomain': cookie_domain, 'cookiePath': cookie_path})
         d = {}
-        for key, val in j.iteritems():
+        for key, val in j.items():
             if val != '':
                 d[key] = val
         return json.dumps(d)


### PR DESCRIPTION
A very simple fix is needed to support Python 3 as well as Python 2. This has been checked and implemented by running all code through the `futurize` script from the python-future package, and then validated in a project running on Python 3.4.